### PR TITLE
make ApiClient#exec() `resolve` 404 Not Found Error to treating as normal flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indeed-job-campaign-api-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "BSD-2-Clause",
   "main": "index.js",
   "devDependencies": {

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -85,7 +85,7 @@ class ApiClient {
    *
    * @param {object} opts
    * @param {number} retry
-   * @return {Promise}
+   * @return {string} - JSON string
    */
   async exec (opts, retry = this.defaultExecRetry) {
     return new Promise((resolve, reject) => {
@@ -101,6 +101,8 @@ class ApiClient {
               await this.oauth.sendRefreshToken()
               this.exec(opts, retry).then(resolve).catch(reject)
             }, wait)
+          } else if (this.isNotFound(e)) {
+            resolve(e.response.text)
           } else {
             const err = new ApiClientExecError()
             err.req = opts
@@ -134,6 +136,14 @@ class ApiClient {
    */
   isUnauthorized (e) {
     return typeof e === 'object' && e.status === 401
+  }
+
+  /**
+   * @param {Error} e
+   * @return {boolean}
+   */
+  isNotFound (e) {
+    return typeof e === 'object' && e.status === 404
   }
 
   /**


### PR DESCRIPTION
ex) A campaign exists, but campaign stats does not exist due to budget limit