### PR TITLE
reject soon when ETIMEDOUT ( 0.2.9 )

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indeed-job-campaign-api-client",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "license": "BSD-2-Clause",
   "main": "index.js",
   "devDependencies": {


### PR DESCRIPTION
## why

 * make application can handle timeout as soon

## points of changes

 * first, detect `Timeout` as an error instead of `NotFound`
 * extract the state of the object that identifies the timeout error into the method
