### PR TITLE
Pull req/force timeout with user fetch (0.3.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indeed-job-campaign-api-client",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "license": "BSD-2-Clause",
   "main": "index.js",
   "devDependencies": {

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -98,18 +98,13 @@ class ApiClient {
           })
           resolve(r.data)
         }).catch(async (e) => {
-          if (this.isTimeout(e)) {
-            const err = new ApiClientExecError()
-            err.req = opts
-            err.swaggerError = e
-            return reject(err)
-          } else if (this.isNotFound(e)) {
+          if (this.isNotFound(e)) {
             resolve(e.response.text)
           } else if (retry > 0) {
-            console.debug({
+            console.debug(JSON.stringify({
               requestOpts: opts,
               error: e
-            })
+            }))
             retry--
 
             if (this.isUnauthorized(e)) await this.oauth.sendRefreshToken()
@@ -159,14 +154,6 @@ class ApiClient {
    */
   isNotFound (e) {
     return typeof e === 'object' && e.status === 404
-  }
-
-  /**
-   * @param {Error} e
-   * @return {boolean}
-   */
-  isTimeout (e) {
-    return e && e.errno === 'ETIMEDOUT' && e.code === 'ETIMEDOUT'
   }
 
   /**

--- a/test/api-client.spec.js
+++ b/test/api-client.spec.js
@@ -48,7 +48,7 @@ describe('ApiClient', () => {
     this.timeout(10000)
 
     beforeEach(async () => {
-      oauth = new OAuthTokenClient(new OAuthTokenStorePlainFile(path.join(__dirname, '../tmp/token-store.json')))
+      oauth = await OAuthTokenClient.create(new OAuthTokenStorePlainFile(path.join(__dirname, '../tmp/token-store.json')))
     })
 
     it('', async () => {

--- a/test/support/dummy-server.js
+++ b/test/support/dummy-server.js
@@ -1,12 +1,23 @@
+const sleep = require('sleep-promise')
 const express = require('express')
 const app = express()
 
 const port = 9292
 
+app.get('/api/v1/account', async (req, res) => {
+  await sleep(10000)
+})
 app.get('*', (req, res) => {
   console.log(req.headers)
   res.send('')
 })
 
-console.log(`start server on http://localhost:${port}`)
-app.listen(port)
+class DummyServer {
+  static run () {
+    console.log(`start server on http://localhost:${port}`)
+
+    return app.listen(port)
+  }
+}
+
+module.exports = DummyServer


### PR DESCRIPTION
## why

allow application to set timeout by using customFetch for SwaggerClient

## points of changes

 * add node-fetch for using as customFetch of swagger-client 
 * remove ApiClient#isTimeout() that detects timeout error from SwaggerError object, because timeout error is not part of that
